### PR TITLE
Pull Request Review: X-HEEP on ZCU104

### DIFF
--- a/core-v-mini-mcu.core
+++ b/core-v-mini-mcu.core
@@ -172,7 +172,6 @@ filesets:
   xdc-fpga-zcu104:
     files:
     - hw/fpga/constraints/zcu104/pin_assign.xdc
-    - hw/fpga/constraints/zcu104/constraints.xdc
     file_type: xdc
 
   netlist-fpga:

--- a/hw/fpga/constraints/zcu104/constraints.xdc
+++ b/hw/fpga/constraints/zcu104/constraints.xdc
@@ -1,1 +1,0 @@
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets x_heep_system_i/pad_ring_i/pad_clk_i/xilinx_iobuf_i/O]

--- a/hw/fpga/constraints/zcu104/pin_assign.xdc
+++ b/hw/fpga/constraints/zcu104/pin_assign.xdc
@@ -2,25 +2,22 @@
 # Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
-# Clock signal
-set_property -dict {PACKAGE_PIN E23 IOSTANDARD LVDS} [get_ports "clk_i_N"] ;# Bank 28 VCCO - VCC1V8 - IO_L13N_T2L_N1_GC_QBC_28
-set_property -dict {PACKAGE_PIN F23 IOSTANDARD LVDS} [get_ports "clk_i_P"] ;# Bank 28 VCCO - VCC1V8 - IO_L13P_T2L_N0_GC_QBC_28
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {clk_i}];
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets jtag_tck_i_IBUF]
+# CLOCK
+set_property -dict {PACKAGE_PIN AH18 IOSTANDARD DIFF_SSTL12} [get_ports clk_300mhz_p]
+set_property -dict {PACKAGE_PIN AH17 IOSTANDARD DIFF_SSTL12} [get_ports clk_300mhz_n]
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets jtag_tck_i]
 
+# RESET
 set_property -dict {PACKAGE_PIN M11 IOSTANDARD LVCMOS33} [get_ports rst_i]
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets rst_i]
 
-# LEDs
-set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports rst_led]
-set_property -dict {PACKAGE_PIN C30 IOSTANDARD LVCMOS33} [get_ports clk_out]
-set_property -dict {PACKAGE_PIN D6 IOSTANDARD LVCMOS33} [get_ports clk_led]
+# LEDS
+set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports rst_led_o]
+set_property -dict {PACKAGE_PIN D6 IOSTANDARD LVCMOS33} [get_ports clk_led_o]
 set_property -dict {PACKAGE_PIN A5 IOSTANDARD LVCMOS33} [get_ports exit_valid_o]
 set_property -dict {PACKAGE_PIN B5 IOSTANDARD LVCMOS33} [get_ports exit_value_o]
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets rst_led_OBUF]
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_out_OBUF]
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_led_OBUF]
 
-#Switches
+# SWITCHES
 set_property -dict {PACKAGE_PIN E4 IOSTANDARD LVCMOS33} [get_ports execute_from_flash_i]
 set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports boot_select_i]
 
@@ -30,77 +27,73 @@ set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports boot_select_i
 # Q1 / MISO
 # Q2 / nWP
 # Q3 / nHLD
-set_property -dict {PACKAGE_PIN L10 IOSTANDARD LVCMOS33} [get_ports spi_flash_csb_o] # Pmod1[4]
-set_property -dict {PACKAGE_PIN J9 IOSTANDARD LVCMOS33} [get_ports spi_flash_sck_o] # Pmod1[0]
-set_property -dict {PACKAGE_PIN M10 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[0]}] # Pmod1[5]
-set_property -dict {PACKAGE_PIN K9 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[1]}] # Pmod1[1]
-set_property -dict {PACKAGE_PIN M8 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[2]}] # Pmod1[6]
-set_property -dict {PACKAGE_PIN K8 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[3]}] # Pmod1[2]
+set_property -dict {PACKAGE_PIN L10 IOSTANDARD LVCMOS33} [get_ports spi_flash_csb_o]
+set_property -dict {PACKAGE_PIN J9 IOSTANDARD LVCMOS33} [get_ports spi_flash_sck_o]
+set_property -dict {PACKAGE_PIN M10 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[0]}]
+set_property -dict {PACKAGE_PIN K9 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[1]}]
+set_property -dict {PACKAGE_PIN M8 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[2]}]
+set_property -dict {PACKAGE_PIN K8 IOSTANDARD LVCMOS33} [get_ports {spi_flash_sd_io[3]}]
 
 # UART
-set_property -dict {PACKAGE_PIN G8 IOSTANDARD LVCMOS33} [get_ports uart_tx_o] # Pmod0[0]
-set_property -dict {PACKAGE_PIN G6 IOSTANDARD LVCMOS33} [get_ports uart_rx_i] # Pmod0[4]
+set_property -dict {PACKAGE_PIN G8 IOSTANDARD LVCMOS33} [get_ports uart_tx_o]
+set_property -dict {PACKAGE_PIN G6 IOSTANDARD LVCMOS33} [get_ports uart_rx_i]
 
 # JTAG
-set_property -dict {PACKAGE_PIN H8 IOSTANDARD LVCMOS33} [get_ports jtag_tdi_i] # Pmod0[1]
-set_property -dict {PACKAGE_PIN J6 IOSTANDARD LVCMOS33} [get_ports jtag_tdo_o] # Pmod0[6]
-set_property -dict {PACKAGE_PIN G7 IOSTANDARD LVCMOS33} [get_ports jtag_tms_i] # Pmod0[2]
-set_property -dict {PACKAGE_PIN H6 IOSTANDARD LVCMOS33} [get_ports jtag_tck_i] # Pmod0[5]
-set_property -dict {PACKAGE_PIN M9 IOSTANDARD LVCMOS33} [get_ports jtag_trst_ni] # Pmod1[7]
+set_property -dict {PACKAGE_PIN H8 IOSTANDARD LVCMOS33} [get_ports jtag_tdi_i]
+set_property -dict {PACKAGE_PIN J6 IOSTANDARD LVCMOS33} [get_ports jtag_tdo_o]
+set_property -dict {PACKAGE_PIN G7 IOSTANDARD LVCMOS33} [get_ports jtag_tms_i]
+set_property -dict {PACKAGE_PIN H6 IOSTANDARD LVCMOS33} [get_ports jtag_tck_i]
+set_property -dict {PACKAGE_PIN M9 IOSTANDARD LVCMOS33} [get_ports jtag_trst_ni]
 
 # I2C
-set_property -dict {PACKAGE_PIN J7 IOSTANDARD LVCMOS33} [get_ports {i2c_scl_io}] # Pmod0[7]
-set_property -dict {PACKAGE_PIN H7 IOSTANDARD LVCMOS33} [get_ports {i2c_sda_io}] # Pmod0[3]
+set_property -dict {PACKAGE_PIN J7 IOSTANDARD LVCMOS33} [get_ports i2c_scl_io]
+set_property -dict {PACKAGE_PIN H7 IOSTANDARD LVCMOS33} [get_ports i2c_sda_io]
 
-###############################
-## The following pins are sent to the FMC connector, using the LA pins as single-ended
-# The bank only supports up to 1.8 V !!!
+## The following pins are sent to the FMC connector, using the LA pins as single-ended.
+## The bank only supports up to 1.8 V.
 
 # SPI SD
-set_property -dict {PACKAGE_PIN H19 IOSTANDARD LVCMOS18} [get_ports spi_csb_o] # fmc_lpc_la06_p
-set_property -dict {PACKAGE_PIN G19 IOSTANDARD LVCMOS18} [get_ports spi_sck_o] # fmc_lpc_la06_n
-set_property -dict {PACKAGE_PIN L15 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[0]}] # fmc_lpc_la10_p
-set_property -dict {PACKAGE_PIN K15 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[1]}] # fmc_lpc_la10_n
-set_property -dict {PACKAGE_PIN C13 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[2]}] # fmc_lpc_la14_p
-set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[3]}] # fmc_lpc_la14_n
+set_property -dict {PACKAGE_PIN H19 IOSTANDARD LVCMOS18} [get_ports spi_csb_o]
+set_property -dict {PACKAGE_PIN G19 IOSTANDARD LVCMOS18} [get_ports spi_sck_o]
+set_property -dict {PACKAGE_PIN L15 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[0]}]
+set_property -dict {PACKAGE_PIN K15 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[1]}]
+set_property -dict {PACKAGE_PIN C13 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[2]}]
+set_property -dict {PACKAGE_PIN C12 IOSTANDARD LVCMOS18} [get_ports {spi_sd_io[3]}]
 
 # GPIOs
-set_property -dict {PACKAGE_PIN A8 IOSTANDARD LVCMOS18} [get_ports {gpio_io[0]}] # fmc_lpc_la27_p
-set_property -dict {PACKAGE_PIN A7 IOSTANDARD LVCMOS18} [get_ports {gpio_io[1]}] # fmc_lpc_la27_n
-set_property -dict {PACKAGE_PIN K17 IOSTANDARD LVCMOS18} [get_ports {gpio_io[2]}] # fmc_lpc_la05_p
-set_property -dict {PACKAGE_PIN J17 IOSTANDARD LVCMOS18} [get_ports {gpio_io[3]}] # fmc_lpc_la05_n
-set_property -dict {PACKAGE_PIN H16 IOSTANDARD LVCMOS18} [get_ports {gpio_io[4]}] # fmc_lpc_la09_p
-set_property -dict {PACKAGE_PIN G16 IOSTANDARD LVCMOS18} [get_ports {gpio_io[5]}] # fmc_lpc_la09_n
-set_property -dict {PACKAGE_PIN G15 IOSTANDARD LVCMOS18} [get_ports {gpio_io[6]}] # fmc_lpc_la13_p
-set_property -dict {PACKAGE_PIN H15 IOSTANDARD LVCMOS18} [get_ports {gpio_io[7]}] # fmc_lpc_la13_n
-set_property -dict {PACKAGE_PIN B11 IOSTANDARD LVCMOS18} [get_ports {gpio_io[8]}] # fmc_lpc_la23_p
-set_property -dict {PACKAGE_PIN A11 IOSTANDARD LVCMOS18} [get_ports {gpio_io[9]}] # fmc_lpc_la23_n
-set_property -dict {PACKAGE_PIN B9 IOSTANDARD LVCMOS18} [get_ports {gpio_io[10]}] # fmc_lpc_la26_p
-set_property -dict {PACKAGE_PIN B8 IOSTANDARD LVCMOS18} [get_ports {gpio_io[11]}] # fmc_lpc_la26_n
-set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS18} [get_ports {gpio_io[12]}] # fmc_lpc_la03_p
-set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS18} [get_ports {gpio_io[13]}] # fmc_lpc_la03_n
-set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS18} [get_ports {gpio_io[14]}] # fmc_lpc_la08_p
+set_property -dict {PACKAGE_PIN D11 IOSTANDARD LVCMOS18} [get_ports {gpio_io[0]}]
+set_property -dict {PACKAGE_PIN D10 IOSTANDARD LVCMOS18} [get_ports {gpio_io[1]}]
+set_property -dict {PACKAGE_PIN A8 IOSTANDARD LVCMOS18} [get_ports {gpio_io[2]}]
+set_property -dict {PACKAGE_PIN A7 IOSTANDARD LVCMOS18} [get_ports {gpio_io[3]}]
+set_property -dict {PACKAGE_PIN H18 IOSTANDARD LVCMOS18} [get_ports {gpio_io[4]}]
+set_property -dict {PACKAGE_PIN H17 IOSTANDARD LVCMOS18} [get_ports {gpio_io[5]}]
+set_property -dict {PACKAGE_PIN K17 IOSTANDARD LVCMOS18} [get_ports {gpio_io[6]}]
+set_property -dict {PACKAGE_PIN J17 IOSTANDARD LVCMOS18} [get_ports {gpio_io[7]}]
+set_property -dict {PACKAGE_PIN H16 IOSTANDARD LVCMOS18} [get_ports {gpio_io[8]}]
+set_property -dict {PACKAGE_PIN G16 IOSTANDARD LVCMOS18} [get_ports {gpio_io[9]}]
+set_property -dict {PACKAGE_PIN G15 IOSTANDARD LVCMOS18} [get_ports {gpio_io[10]}]
+set_property -dict {PACKAGE_PIN F15 IOSTANDARD LVCMOS18} [get_ports {gpio_io[11]}]
+set_property -dict {PACKAGE_PIN F11 IOSTANDARD LVCMOS18} [get_ports {gpio_io[12]}]
+set_property -dict {PACKAGE_PIN E10 IOSTANDARD LVCMOS18} [get_ports {gpio_io[13]}]
+set_property -dict {PACKAGE_PIN B11 IOSTANDARD LVCMOS18} [get_ports {gpio_io[14]}]
+set_property -dict {PACKAGE_PIN A11 IOSTANDARD LVCMOS18} [get_ports {gpio_io[15]}]
+set_property -dict {PACKAGE_PIN B9 IOSTANDARD LVCMOS18} [get_ports {gpio_io[16]}]
+set_property -dict {PACKAGE_PIN B8 IOSTANDARD LVCMOS18} [get_ports {gpio_io[17]}]
 
 # PDM2PCM
-set_property -dict {PACKAGE_PIN G18 IOSTANDARD LVCMOS18} [get_ports {pdm2pcm_clk_io}] # fmc_lpc_la12_p
-set_property -dict {PACKAGE_PIN F18 IOSTANDARD LVCMOS18} [get_ports {pdm2pcm_pdm_io}] # fmc_lpc_la12_n
+set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS18} [get_ports pdm2pcm_clk_io]
+set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS18} [get_ports pdm2pcm_pdm_io]
 
 # I2S
-set_property -dict {PACKAGE_PIN D17 IOSTANDARD LVCMOS18} [get_ports {i2s_sck_io}] # fmc_lpc_la16_p
-set_property -dict {PACKAGE_PIN C17 IOSTANDARD LVCMOS18} [get_ports {i2s_ws_io}] # fmc_lpc_la16_n
-set_property -dict {PACKAGE_PIN F12 IOSTANDARD LVCMOS18} [get_ports {i2s_sd_io}] # fmc_lpc_la20_p
+set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS18} [get_ports i2s_sck_io]
+set_property -dict {PACKAGE_PIN E17 IOSTANDARD LVCMOS18} [get_ports i2s_ws_io]
+set_property -dict {PACKAGE_PIN G18 IOSTANDARD LVCMOS18} [get_ports i2s_sd_io]
 
 # SPI2
-set_property -dict {PACKAGE_PIN H13 IOSTANDARD LVCMOS18} [get_ports {spi2_csb_o[0]}] # fmc_lpc_la22_p
-set_property -dict {PACKAGE_PIN H12 IOSTANDARD LVCMOS18} [get_ports {spi2_csb_o[1]}] # fmc_lpc_la22_n
-set_property -dict {PACKAGE_PIN C7 IOSTANDARD LVCMOS18} [get_ports {spi2_sck_o}] # fmc_lpc_la25_p
-set_property -dict {PACKAGE_PIN C6 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[0]}] # fmc_lpc_la25_n
-set_property -dict {PACKAGE_PIN K10 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[1]}] # fmc_lpc_la29_p
-set_property -dict {PACKAGE_PIN J10 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[2]}] # fmc_lpc_la29_n
-set_property -dict {PACKAGE_PIN F7 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[3]}] # fmc_lpc_la31_p
-
-# Tri-color LEDs for TARGET_PYNQ_Z2
-set_property -dict {PACKAGE_PIN C9 IOSTANDARD LVCMOS18} [get_ports {gpio_io[15]}] # fmc_lpc_lafmc_lpc_la33_p
-set_property -dict {PACKAGE_PIN C8 IOSTANDARD LVCMOS18} [get_ports {gpio_io[16]}] # fmc_lpc_la33_n
-set_property -dict {PACKAGE_PIN L20 IOSTANDARD LVCMOS18} [get_ports {gpio_io[17]}] # fmc_lpc_la02_p
-
+set_property -dict {PACKAGE_PIN F18 IOSTANDARD LVCMOS18} [get_ports {spi2_csb_o[0]}]
+set_property -dict {PACKAGE_PIN D17 IOSTANDARD LVCMOS18} [get_ports {spi2_csb_o[1]}]
+set_property -dict {PACKAGE_PIN C17 IOSTANDARD LVCMOS18} [get_ports spi2_sck_o]
+set_property -dict {PACKAGE_PIN F12 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[0]}]
+set_property -dict {PACKAGE_PIN E12 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[1]}]
+set_property -dict {PACKAGE_PIN H13 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[2]}]
+set_property -dict {PACKAGE_PIN H12 IOSTANDARD LVCMOS18} [get_ports {spi2_sd_io[3]}]

--- a/hw/fpga/scripts/zcu104/xilinx_generate_clk_wizard.tcl
+++ b/hw/fpga/scripts/zcu104/xilinx_generate_clk_wizard.tcl
@@ -3,42 +3,38 @@
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 # Define design macros
 
-set design_name      xilinx_clk_wizard
-set in_clk_freq_MHz  125
-set out_clk_freq_MHz 15
-
+set design_name xilinx_clk_wizard
 
 # Create block design
 create_bd_design $design_name
 
-# Create ports
-set clk_125MHz [ create_bd_port -dir I -type clk -freq_hz [ expr $in_clk_freq_MHz * 1000000 ] clk_125MHz ]
-set clk_out1_0 [ create_bd_port -dir O -type clk clk_out1_0 ]
-set_property -dict [ list CONFIG.FREQ_HZ [ expr $out_clk_freq_MHz * 1000000 ] ] $clk_out1_0
-
-
 # Create instance and set properties
-set clk_wiz_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:6.0 clk_wiz_0 ]
-set_property -dict [ list \
- CONFIG.CLKOUT1_JITTER {323.873} \
- CONFIG.CLKOUT1_PHASE_ERROR {394.762} \
- CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {15} \
- CONFIG.MMCM_CLKFBOUT_MULT_F {111.375} \
- CONFIG.MMCM_CLKOUT0_DIVIDE_F {74.250} \
- CONFIG.MMCM_DIVCLK_DIVIDE {10} \
- CONFIG.PRIM_IN_FREQ $in_clk_freq_MHz \
- CONFIG.USE_LOCKED {false} \
- CONFIG.USE_RESET {false} \
- ] $clk_wiz_0
+create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:6.0 clk_wiz_0
+set_property -dict [list \
+  CONFIG.CLKIN1_JITTER_PS {33.330000000000005} \
+  CONFIG.CLKOUT1_JITTER {282.792} \
+  CONFIG.CLKOUT1_PHASE_ERROR {207.545} \
+  CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {15} \
+  CONFIG.CLK_IN1_BOARD_INTERFACE {clk_300mhz} \
+  CONFIG.MMCM_CLKFBOUT_MULT_F {32.875} \
+  CONFIG.MMCM_CLKIN1_PERIOD {3.333} \
+  CONFIG.MMCM_CLKIN2_PERIOD {10.0} \
+  CONFIG.MMCM_CLKOUT0_DIVIDE_F {65.750} \
+  CONFIG.MMCM_DIVCLK_DIVIDE {10} \
+  CONFIG.OPTIMIZE_CLOCKING_STRUCTURE_EN {true} \
+  CONFIG.PRIM_SOURCE {Differential_clock_capable_pin} \
+  CONFIG.USE_LOCKED {false} \
+  CONFIG.USE_RESET {true} \
+] [get_bd_cells clk_wiz_0]
 
-# Create port connections
-connect_bd_net -net clk_in1_0_1 [get_bd_ports clk_125MHz] [get_bd_pins clk_wiz_0/clk_in1]
-connect_bd_net -net clk_wiz_0_clk_out1 [ get_bd_ports clk_out1_0 ] [ get_bd_pins clk_wiz_0/clk_out1 ]
+# Create ports
+make_bd_pins_external [get_bd_cells clk_wiz_0]
+make_bd_intf_pins_external [get_bd_cells clk_wiz_0]
 
 # Save and close block design
 save_bd_design
 close_bd_design $design_name
 
-# create wrapper
+# Create wrapper
 set wrapper_path [ make_wrapper -fileset sources_1 -files [ get_files -norecurse xilinx_clk_wizard.bd ] -top ]
 add_files -norecurse -fileset sources_1 $wrapper_path

--- a/hw/vendor/pulp_platform_gpio.core
+++ b/hw/vendor/pulp_platform_gpio.core
@@ -44,3 +44,4 @@ targets:
     - target_nexys-a7-100t? (no-clock-gate)
     - target_pynq-z2? (no-clock-gate)
     - target_pynq-z2-arm-emulation? (no-clock-gate)
+    - target_zcu104? (no-clock-gate)

--- a/sw/device/target/zcu104/x-heep.h
+++ b/sw/device/target/zcu104/x-heep.h
@@ -1,0 +1,28 @@
+// Copyright EPFL contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef X_HEEP
+#define X_HEEP
+
+#pragma message ( "the x-heep.h for ZCU104 is used" )
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define UART_BAUDRATE 9600
+#define TARGET_ZCU104 1
+
+/**
+ * As the hw is configurable, we can have setups with different number of
+ * Gpio pins
+ */
+#define MAX_PIN 32
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // X_HEEP


### PR DESCRIPTION
I implemented the following changes:

- Fixed GPIO vendorization to avoid the usage of clock-gating cells.
- Removed constraints file because unused.
- Updated FPGA top-level wrapper to better differentiate between the 3 supported boards (Pynq-Z2, Nexys, and ZCU104) using defines. 
- Added software target for ZCU104 to set system clock frequency (15 MHz) and UART baud rate (9600).
- Fixed clock wizard generation script to use the differential 300 MHz input clock.
- Fixed pin assignment to 1) use the differential 300 MHz input clock; 2) remove comments due to wrong syntax (comments must start with ;#); 3) Rearrange some pins for clearness.

This PR can be merged but does NOT completely fix PR https://github.com/esl-epfl/x-heep/pull/435. Some additional changes have to be implemented:

- Fix hold violations in I2S peripheral when implemented on ZCU104.
- Align and check the correct behavior of Pynq-Z2 and Nexys implementations.